### PR TITLE
Feature/multiple pages

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,27 +4,41 @@ const path = require("path");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const WorkboxWebpackPlugin = require("workbox-webpack-plugin");
 
-const isProduction = process.env.NODE_ENV == "production";
+const isProduction = process.env.NODE_ENV === "production";
 
 const stylesHandler = "style-loader";
 
+const pages = ["index", "fill-out-report"];
+
 const config = {
-  entry: "./src/index.js",
+  entry: pages.reduce((config, page) => {
+    config[page] = `./src/${page}.js`;
+    return config;
+  }, {}),
   output: {
-    path: path.resolve(__dirname, "dist"),
+    filename: '[name].js',
+    path: path.resolve(__dirname, "dist")
+  },
+  optimization: {
+    splitChunks: {
+      chunks: "all",
+    },
   },
   devServer: {
     open: true,
     host: "localhost",
   },
-  plugins: [
-    new HtmlWebpackPlugin({
-      template: "index.html",
-    }),
-
-    // Add your plugins here
-    // Learn more about plugins from https://webpack.js.org/configuration/plugins/
-  ],
+  plugins: [].concat(
+      pages.map(
+          (page) =>
+              new HtmlWebpackPlugin({
+                inject: true,
+                template: `./${page}.html`,
+                filename: `${page}.html`,
+                chunks: [page],
+              })
+      )
+  ),
   module: {
     rules: [
       {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,9 @@ const isProduction = process.env.NODE_ENV === "production";
 
 const stylesHandler = "style-loader";
 
-const pages = ["index", "fill-out-report"];
+const pages = [
+    "index"
+];
 
 const config = {
   entry: pages.reduce((config, page) => {


### PR DESCRIPTION
Finally made a working convenient config for multiple pages.

To add your new page:
- Copy and rename `src/index.js` to your page name (`fill-out-report.js` for example)
- add your page name to `pages` array in `webpack.config.js` like this:
```js
const pages = [
    "index",
    "fill-out-report" // new page added
];
```